### PR TITLE
Define and use "Solo Operation" to switch support obligations

### DIFF
--- a/terms.cform
+++ b/terms.cform
@@ -26,9 +26,9 @@
 
         \Solo Operation\  <Developer> is a ""Solo Operation"" is, on the date of this agreement, <Developer> is an individual or a company with just one technical person capable of responding to <Support Requests>.
 
-        \Technical Support Escalation\  If <Developer> is a company of more than one person, then <Developer> agrees to promptly escalate <Support Requests> that initially responding support personnel cannot resolve independently to a <Developer> engineer responsible for the <Software>.  Where appropriate, initially responding support personnel may connect <Customer Personnel> to engineers directly.
+        \Technical Support Escalation\  If <Developer> is not a <Solo Operation>, then <Developer> agrees to promptly escalate <Support Requests> that initially responding support personnel cannot resolve independently to a <Developer> engineer responsible for the <Software>.  Where appropriate, initially responding support personnel may connect <Customer Personnel> to engineers directly.
 
-        \Dedicated Support Personnel\  If <Developer> is a company of more than one person and the <Order Form> specifies dedicated support personnel, then <Developer> agrees to assign a limited number of specific support personnel to respond to <Customer>'s <Support Requests>, in order to maximize the chance that <Customer Personnel> will receive support from personnel familiar with <Customer>'s use cases and past<Support Requests>.
+        \Dedicated Support Personnel\  If <Developer> is not a <Solo Operation> and the <Order Form> specifies dedicated support personnel, then <Developer> agrees to assign a limited number of specific support personnel to respond to <Customer>'s <Support Requests>, in order to maximize the chance that <Customer Personnel> will receive support from personnel familiar with <Customer>'s use cases and past<Support Requests>.
 
         \Service-Level Agreement\  If the <Order Form> specifies a service-level agreement:
 
@@ -40,7 +40,7 @@
 
             \Holidays\  If the <Order Form> specifies holidays, <Developer> will not respond to <Support Requests> on those holidays.  If the <Order Form> does not specify holidays, <Developer> will not respond to <Support Requests> on days when commercial banks in the city nearest <Developer's Address> typically stay closed.
 
-            \Vacation and Sick Days\  If <Developer> is an individual or a company of one person, then <Developer> will not respond to <Support Requests> on days <Developer> takes off as vacation or sick days.  <Developer> agrees to give <Notice> of sick days, and advance <Notice> of vacation days.  <Developer> may take as many sick days and vacation days as <Customer>'s human resources policies allow full-time employees to take, or if <Customer> does not have such a policy, a reasonable number of sick days and vacation days.
+            \Vacation and Sick Days\  If <Developer> is a <Solo Operation>, then <Developer> will not respond to <Support Requests> on days <Developer> takes off as vacation or sick days.  <Developer> agrees to give <Notice> of sick days, and advance <Notice> of vacation days.  <Developer> may take as many sick days and vacation days as <Customer>'s human resources policies allow full-time employees to take, or if <Customer> does not have such a policy, a reasonable number of sick days and vacation days.
 
             \Support Request Severity\
 

--- a/terms.cform
+++ b/terms.cform
@@ -24,6 +24,8 @@
 
         \Diagnosis and Resolution\  <Developer> agrees to diagnose and resolve <Support Requests> related to installing <Covered Versions> of the <Software>, configuring standard features of <Covered Versions> of the <Software> per its documentation, and software errors encountered when using <Covered Versions> of the <Software>.
 
+        \Solo Operation\  <Developer> is a ""Solo Operation"" is, on the date of this agreement, <Developer> is an individual or a company with just one technical person capable of responding to <Support Requests>.
+
         \Technical Support Escalation\  If <Developer> is a company of more than one person, then <Developer> agrees to promptly escalate <Support Requests> that initially responding support personnel cannot resolve independently to a <Developer> engineer responsible for the <Software>.  Where appropriate, initially responding support personnel may connect <Customer Personnel> to engineers directly.
 
         \Dedicated Support Personnel\  If <Developer> is a company of more than one person and the <Order Form> specifies dedicated support personnel, then <Developer> agrees to assign a limited number of specific support personnel to respond to <Customer>'s <Support Requests>, in order to maximize the chance that <Customer Personnel> will receive support from personnel familiar with <Customer>'s use cases and past<Support Requests>.

--- a/terms.md
+++ b/terms.md
@@ -32,6 +32,10 @@ If the _Order Form_ specifies support channels, _Developer_ only agrees to respo
 
 _Developer_ agrees to diagnose and resolve _Support Requests_ related to installing _Covered Versions_ of the _Software_, configuring standard features of _Covered Versions_ of the _Software_ per its documentation, and software errors encountered when using _Covered Versions_ of the _Software_.
 
+### <a id="Solo_Operation"></a>Solo Operation
+
+_Developer_ is a **Solo Operation** is, on the date of this agreement, _Developer_ is an individual or a company with just one technical person capable of responding to _Support Requests_.
+
 ### <a id="Technical_Support_Escalation"></a>Technical Support Escalation
 
 If _Developer_ is a company of more than one person, then _Developer_ agrees to promptly escalate _Support Requests_ that initially responding support personnel cannot resolve independently to a _Developer_ engineer responsible for the _Software_. Where appropriate, initially responding support personnel may connect _Customer Personnel_ to engineers directly.

--- a/terms.md
+++ b/terms.md
@@ -38,11 +38,11 @@ _Developer_ is a **Solo Operation** is, on the date of this agreement, _Develope
 
 ### <a id="Technical_Support_Escalation"></a>Technical Support Escalation
 
-If _Developer_ is a company of more than one person, then _Developer_ agrees to promptly escalate _Support Requests_ that initially responding support personnel cannot resolve independently to a _Developer_ engineer responsible for the _Software_. Where appropriate, initially responding support personnel may connect _Customer Personnel_ to engineers directly.
+If _Developer_ is not a _Solo Operation_, then _Developer_ agrees to promptly escalate _Support Requests_ that initially responding support personnel cannot resolve independently to a _Developer_ engineer responsible for the _Software_. Where appropriate, initially responding support personnel may connect _Customer Personnel_ to engineers directly.
 
 ### <a id="Dedicated_Support_Personnel"></a>Dedicated Support Personnel
 
-If _Developer_ is a company of more than one person and the _Order Form_ specifies dedicated support personnel, then _Developer_ agrees to assign a limited number of specific support personnel to respond to _Customer_'s _Support Requests_, in order to maximize the chance that _Customer Personnel_ will receive support from personnel familiar with _Customer_'s use cases and past_Support Requests_.
+If _Developer_ is not a _Solo Operation_ and the _Order Form_ specifies dedicated support personnel, then _Developer_ agrees to assign a limited number of specific support personnel to respond to _Customer_'s _Support Requests_, in order to maximize the chance that _Customer Personnel_ will receive support from personnel familiar with _Customer_'s use cases and past_Support Requests_.
 
 ### <a id="Service-Level_Agreement"></a>Service-Level Agreement
 
@@ -66,7 +66,7 @@ If the _Order Form_ specifies holidays, _Developer_ will not respond to _Support
 
 #### <a id="Vacation_and_Sick_Days"></a>Vacation and Sick Days
 
-If _Developer_ is an individual or a company of one person, then _Developer_ will not respond to _Support Requests_ on days _Developer_ takes off as vacation or sick days. _Developer_ agrees to give _Notice_ of sick days, and advance _Notice_ of vacation days. _Developer_ may take as many sick days and vacation days as _Customer_'s human resources policies allow full-time employees to take, or if _Customer_ does not have such a policy, a reasonable number of sick days and vacation days.
+If _Developer_ is a _Solo Operation_, then _Developer_ will not respond to _Support Requests_ on days _Developer_ takes off as vacation or sick days. _Developer_ agrees to give _Notice_ of sick days, and advance _Notice_ of vacation days. _Developer_ may take as many sick days and vacation days as _Customer_'s human resources policies allow full-time employees to take, or if _Customer_ does not have such a policy, a reasonable number of sick days and vacation days.
 
 #### <a id="Support_Request_Severity"></a>Support Request Severity
 


### PR DESCRIPTION
This PR adds a definition of "Solo Operation", and uses it to switch various terms that only make sense with multiple support staff on and off.

With thanks to @briansmith

Ref: <https://twitter.com/BRIAN_____/status/1091132407112130560>