### PR TITLE
Respond to Critical Support Requests on off days

### DIFF
--- a/terms.cform
+++ b/terms.cform
@@ -34,11 +34,11 @@
 
             \Refund Prepaid Fees\  If <Developer> fails to meet {Meet or Exceed Service Levels} for three <Billing Periods> in a row, and <Customer> ends this agreement at the end of those <Billing Periods>, citing poor support responsiveness, <Developer> agrees to refund any <Prepaid Fees>.
 
-            \Business Hours\  If the <Order Form> specifies business hours, <Developer> agrees to respond to <Support Requests> during those hours.  If the <Order Form> does not specify business hours, <Developer> agrees to respond to <Support Requests> during regular business hours in the time zone of <Developer's Address>.
+            \Business Hours\  If the <Order Form> specifies business hours, <Developer> agrees to respond to <Regular Support Requests> only during those hours.  If the <Order Form> does not specify business hours, <Developer> agrees to respond to <Regular Support Requests> only during regular business hours in the time zone of <Developer's Address>.
 
-            \Holidays\  If the <Order Form> specifies holidays, <Developer> will not respond to <Support Requests> on those holidays.  If the <Order Form> does not specify holidays, <Developer> will not respond to <Support Requests> on days when commercial banks in the city nearest <Developer's Address> typically stay closed.
+            \Holidays\  If the <Order Form> specifies holidays, <Developer> will not respond to <Regular Support Requests> on those holidays.  If the <Order Form> does not specify holidays, <Developer> will not respond to <Regular Support Requests> on days when commercial banks in the city nearest <Developer's Address> typically stay closed.
 
-            \Vacation and Sick Days\  If <Developer> is an individual or a company of one person, then <Developer> will not respond to <Support Requests> on days <Developer> takes off as vacation or sick days.  <Developer> agrees to give <Notice> of sick days, and advance <Notice> of vacation days.  <Developer> may take as many sick days and vacation days as <Customer>'s human resources policies allow full-time employees to take, or if <Customer> does not have such a policy, a reasonable number of sick days and vacation days.
+            \Vacation and Sick Days\  If <Developer> is an individual or a company of one person, then <Developer> will not respond to any <Support Requests> on days <Developer> takes off as vacation or sick days.  <Developer> agrees to give <Notice> of sick days, and advance <Notice> of vacation days.  <Developer> may take as many sick days and vacation days as <Customer>'s human resources policies allow full-time employees to take, or if <Customer> does not have such a policy, a reasonable number of sick days and vacation days.
 
             \Support Request Severity\
 

--- a/terms.md
+++ b/terms.md
@@ -54,15 +54,15 @@ If _Developer_ fails to meet [Meet or Exceed Service Levels](#Meet_or_Exceed_Ser
 
 #### <a id="Business_Hours"></a>Business Hours
 
-If the _Order Form_ specifies business hours, _Developer_ agrees to respond to _Support Requests_ during those hours. If the _Order Form_ does not specify business hours, _Developer_ agrees to respond to _Support Requests_ during regular business hours in the time zone of _Developer's Address_.
+If the _Order Form_ specifies business hours, _Developer_ agrees to respond to _Regular Support Requests_ only during those hours. If the _Order Form_ does not specify business hours, _Developer_ agrees to respond to _Regular Support Requests_ only during regular business hours in the time zone of _Developer's Address_.
 
 #### <a id="Holidays"></a>Holidays
 
-If the _Order Form_ specifies holidays, _Developer_ will not respond to _Support Requests_ on those holidays. If the _Order Form_ does not specify holidays, _Developer_ will not respond to _Support Requests_ on days when commercial banks in the city nearest _Developer's Address_ typically stay closed.
+If the _Order Form_ specifies holidays, _Developer_ will not respond to _Regular Support Requests_ on those holidays. If the _Order Form_ does not specify holidays, _Developer_ will not respond to _Regular Support Requests_ on days when commercial banks in the city nearest _Developer's Address_ typically stay closed.
 
 #### <a id="Vacation_and_Sick_Days"></a>Vacation and Sick Days
 
-If _Developer_ is an individual or a company of one person, then _Developer_ will not respond to _Support Requests_ on days _Developer_ takes off as vacation or sick days. _Developer_ agrees to give _Notice_ of sick days, and advance _Notice_ of vacation days. _Developer_ may take as many sick days and vacation days as _Customer_'s human resources policies allow full-time employees to take, or if _Customer_ does not have such a policy, a reasonable number of sick days and vacation days.
+If _Developer_ is an individual or a company of one person, then _Developer_ will not respond to any _Support Requests_ on days _Developer_ takes off as vacation or sick days. _Developer_ agrees to give _Notice_ of sick days, and advance _Notice_ of vacation days. _Developer_ may take as many sick days and vacation days as _Customer_'s human resources policies allow full-time employees to take, or if _Customer_ does not have such a policy, a reasonable number of sick days and vacation days.
 
 #### <a id="Support_Request_Severity"></a>Support Request Severity
 


### PR DESCRIPTION
This PR changes two sections about days off to let the Developer off of responding only to Regular Support Requests. The Developer will have to respond to Critical Support Requests on those days.

With thanks to @briansmith.

Ref: <https://twitter.com/BRIAN_____/status/1091143435052933121>