### PR TITLE
Add Supported Systems

### DIFF
--- a/terms.cform
+++ b/terms.cform
@@ -22,6 +22,8 @@
 
         \Support Channels\  If the <Order Form> specifies support channels, <Developer> only agrees to respond to <Support Requests> sent via those channels.  If the <Order Form> does not specify support channels, <Developer> only agrees to respond to <Support Requests> via e-mail, and to give <Notice> of an e-mail address for <Support Requests> on entering into this agreement.
 
+        \Supported Systems\  <Developer> only agrees to respond to <Support Requests> for installations of the <Software> on supported operating systems, as identified in its documentation.
+
         \Diagnosis and Resolution\  <Developer> agrees to diagnose and resolve <Support Requests> related to installing <Covered Versions> of the <Software>, configuring standard features of <Covered Versions> of the <Software> per its documentation, and software errors encountered when using <Covered Versions> of the <Software>.
 
         \Technical Support Escalation\  If <Developer> is a company of more than one person, then <Developer> agrees to promptly escalate <Support Requests> that initially responding support personnel cannot resolve independently to a <Developer> engineer responsible for the <Software>.  Where appropriate, initially responding support personnel may connect <Customer Personnel> to engineers directly.

--- a/terms.md
+++ b/terms.md
@@ -28,6 +28,10 @@ _Developer_ agrees to respond to **Support Requests** from _Customer Personnel_ 
 
 If the _Order Form_ specifies support channels, _Developer_ only agrees to respond to _Support Requests_ sent via those channels. If the _Order Form_ does not specify support channels, _Developer_ only agrees to respond to _Support Requests_ via e-mail, and to give _Notice_ of an e-mail address for _Support Requests_ on entering into this agreement.
 
+### <a id="Supported_Systems"></a>Supported Systems
+
+_Developer_ only agrees to respond to _Support Requests_ for installations of the _Software_ on supported operating systems, as identified in its documentation.
+
 ### <a id="Diagnosis_and_Resolution"></a>Diagnosis and Resolution
 
 _Developer_ agrees to diagnose and resolve _Support Requests_ related to installing _Covered Versions_ of the _Software_, configuring standard features of _Covered Versions_ of the _Software_ per its documentation, and software errors encountered when using _Covered Versions_ of the _Software_.


### PR DESCRIPTION
Inspired by @aaronsaray, this PR adds an additional section making clear that support will only cover installations on supported operating systems. The software documentation determines which operating systems.