### PR TITLE
Support Request Severity: Allow override (close #5)

### DIFF
--- a/terms.cform
+++ b/terms.cform
@@ -40,7 +40,7 @@
 
             \Vacation and Sick Days\  If <Developer> is an individual or a company of one person, then <Developer> will not respond to <Support Requests> on days <Developer> takes off as vacation or sick days.  <Developer> agrees to give <Notice> of sick days, and advance <Notice> of vacation days.  <Developer> may take as many sick days and vacation days as <Customer>'s human resources policies allow full-time employees to take, or if <Customer> does not have such a policy, a reasonable number of sick days and vacation days.
 
-            \Support Request Severity\
+            \Support Request Severity\  Unless the <Order Form> defines different terms for the severity of <Support Requests>:
 
                 \\  ""Critical Support Requests"" are <Support Requests> that report that:
 

--- a/terms.md
+++ b/terms.md
@@ -68,6 +68,8 @@ If _Developer_ is an individual or a company of one person, then _Developer_ wil
 
 #### <a id="Support_Request_Severity"></a>Support Request Severity
 
+Unless the _Order Form_ defines different terms for the severity of _Support Requests_:
+
 1.  **Critical Support Requests** are _Support Requests_ that report that:
 
     1.  _Customer_ cannot install the _Software_ by following the directions in its documentation.


### PR DESCRIPTION
This PR allows order forms to override the severity-triage definitions of the legal terms.

This will allow developers to write SLAs in their own terms, with their own customer definitions of various severities.